### PR TITLE
fix: handle null targets in package exports

### DIFF
--- a/src/project-utils/filter.ts
+++ b/src/project-utils/filter.ts
@@ -15,6 +15,7 @@ function hasExportsSourceField(
     Object.values(exportsConfig).some(
       (moduleRules) =>
         typeof moduleRules === 'object' &&
+        moduleRules !== null &&
         typeof moduleRules[sourceField] === 'string',
     )
   );

--- a/src/project.ts
+++ b/src/project.ts
@@ -140,6 +140,7 @@ export class Project {
     for (const moduleRules of Object.values(exportsConfig)) {
       if (
         typeof moduleRules === 'object' &&
+        moduleRules !== null &&
         typeof moduleRules[sourceField] === 'string'
       ) {
         exportsSourceDirs.push(

--- a/src/types/packageJson.ts
+++ b/src/types/packageJson.ts
@@ -62,6 +62,7 @@ export interface IPeerDependenciesMetaTable {
 }
 
 export type ExportsModuleRules =
+  | null
   | string
   | Record<string, string>
   | Record<string, string | Record<string, string>>;

--- a/test/components/package.json
+++ b/test/components/package.json
@@ -13,7 +13,8 @@
       "types": "./dist/types/card/index.d.ts",
       "source": "./src/card/index.tsx",
       "default": "./dist/card/index.js"
-    }
+    },
+    "./*.test": null
   },
   "dependencies": {
     "@e2e/source-build-utils": "workspace:*",


### PR DESCRIPTION
## Summary

- handle `null` targets when scanning the `exports` field
- support `null` in the package exports type definition
- add a regression case for blocked subpath patterns such as `"./*.test": null`

## Background

Node.js supports using `null` targets to exclude private subpaths from export patterns, as documented in [Subpath patterns](https://nodejs.org/api/packages.html#subpath-patterns).

```json
{
  "exports": {
    "./*.test": null,
    "./*": {
      "source": "./src/*.ts"
    }
  }
}
```

Because `typeof null === 'object'`, the plugin previously treated the `null` target as an conditional exports object and attempted to read the configured source field from it. This resulted in an error such as:

```
TypeError: Cannot read properties of null (reading 'source')
```
